### PR TITLE
[FIX] graphql_vuestorefront: get_product_price

### DIFF
--- a/graphql_vuestorefront/models/product.py
+++ b/graphql_vuestorefront/models/product.py
@@ -103,9 +103,9 @@ class ProductTemplate(models.Model):
 
         discount = 0
         discount_perc = 0
-        if combination_info['has_discounted_price']:
+        if combination_info['has_discounted_price'] and product_id:
             product = self.env['product.product'].search([('id', '=', product_id)])
-            combination_info['price'] = pricelist.get_product_price(product, add_qty, self.env.user.partner_id)
+            combination_info['price'] = pricelist._get_product_price(product, add_qty, self.env.user.partner_id)
             discount = combination_info['list_price'] - combination_info['price']
             discount_perc = combination_info['list_price'] and (discount * 100 / combination_info['list_price']) or 0
 


### PR DESCRIPTION
There is no such method `get_product_price` in `product.pricelist` ( it was changed to `_get_product_price` ~2 years ago).

Also, we must check if `product_id` exists, because it will break `_get_product_price` call, which expects `product` to be non empty!